### PR TITLE
Wechsel auf Standardports (80/443/3306)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,12 @@ Oder praktischerweise zusammengefasst (Alle Images bauen und alle Container neus
 
 __REDAXO im Browser aufrufen:__
 
-     http://localhost:20080
-    https://localhost:20443
-
-:point_right: _Wir benutzen Port `20080` für HTTP, `20443` für HTTPS und `23306` für die Datenbank, um nicht in Konflikt mit den Standardports `80`/`443`/`3306` zu kommen, sollten diese bereits verwendet werden. Das macht unser Setup robuster.  
-Wenn du mehrere Docker-Projekte verwendest, musst du noch beachten, dass alle diese Ports verwenden und deshalb immer nur eins laufen kann, nicht mehrere gleichzeitig._
+     http://localhost
+    https://localhost
 
 :point_right: _Für den Zugriff mittels HTTPS wird ein SSL-Zertifikat generiert, das nur für Testzwecke funktioniert. Dein Browser wird dich darauf hinweisen, dass die Verbindung nicht sicher ist. Zum lokalen Testen allerdings reicht das völlig aus, und du kannst den Sicherheitshinweis übergehen._
+
+:point_right: _Wenn du mehrere Docker-Projekte verwendest, musst du beachten, dass alle die gleichen Ports verwenden und deshalb immer nur eins laufen kann, nicht mehrere gleichzeitig._
 
 ---
 
@@ -152,7 +151,7 @@ FROM mysql:5.7
 
 Wir haben [Mailhog](https://github.com/mailhog/MailHog) integriert, um den E-Mailversand innerhalb von REDAXO testen zu können, ohne dass dabei ein echtes E-Mailkonto angebunden werden muss. Mailhog fängt stattdessen die Mails ab und bietet eine Weboberfläche, um sie anzuzeigen. Sie ist erreichbar über:
 
-    http://localhost:28025
+    http://localhost:8025
 
 :point_right: _Tip: Im REDAXO-Backend musst du im AddOn PHPMailer nichts weiter konfigurieren. Benutze den Standardversand über `mail()` und sende eine Testmail an dich. Diese sollte direkt im Mailhog auftauchen._
 
@@ -168,7 +167,7 @@ phpmyadmin:
   hostname: redaxodocker_phpmyadmin
   image: phpmyadmin/phpmyadmin
   ports:
-    - 28080:80
+    - 81:80
   depends_on:
     - db
   environment:
@@ -185,7 +184,7 @@ Docker-Container neustarten:
 
 Danach ist phpMyAdmin erreichbar über:
 
-    http://localhost:28080
+    http://localhost:81
 
 ---
 
@@ -214,7 +213,7 @@ Das wird beim ersten Mal ein kleines Weilchen dauern, weil zuerst die _Images_ r
 
 Danach steht dir ein frisches REDAXO inkl. [Demo-Website](https://github.com/FriendsOfREDAXO/demo_base) im Browser zur Verfügung unter:
 
-    http://localhost:20080
+    http://localhost
 
 Ins REDAXO-Backend kannst du dich einloggen mit `admin`/`admin`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     hostname: redaxodocker
     build: ./docker/php-apache              # location for web server dockerfile and config
     ports:
-      - 20080:80                            # web server will use port 20080 for http
-      - 20443:443                           # web server will use port 20443 for https
+      - 80:80                               # web server will use port 80 for http
+      - 443:443                             # web server will use port 443 for https
     volumes:
       - ./html:/var/www/html:cached         # webroot `/var/www/html` will be synced with your local folder `./html`
     depends_on:
@@ -19,14 +19,14 @@ services:
     environment:
       REDAXO_USER: admin                    # username of your new REDAXO admin
       REDAXO_PASSWORD: admin                # password of your new REDAXO admin
-      REDAXO_DEMO: demo_base                # website demo to be installed. leave empty for a raw REDAXO!
+      REDAXO_DEMO: demo_onepage             # website demo to be installed. leave empty for a raw REDAXO!
 
   db:
     container_name: redaxodocker_db
     hostname: redaxodocker_db
     build: ./docker/mysql                   # location for database dockerfile and config
     ports:
-      - 23306:3306                          # database will use port 23306
+      - 3306:3306                           # database will use port 3306
     volumes:
       - ./db:/var/lib/mysql:cached          # database in `/var/lib/mysql` will be synced with your local folder `./db`
     environment:
@@ -40,4 +40,4 @@ services:
     hostname: redaxodocker_mail
     build: ./docker/mailhog                 # location for mailhog dockerfile and config
     ports:
-      - 28025:8025                          # mailhog will use port 28025 (for its web interface)
+      - 8025:8025                           # mailhog will use port 8025 (for its web interface)

--- a/docker/php-apache/Dockerfile
+++ b/docker/php-apache/Dockerfile
@@ -6,11 +6,11 @@ COPY apache.conf /etc/apache2/sites-available/000-default.conf
 COPY ssmtp.conf /etc/ssmtp/
 
 # generate SSL cert for testing purposes
-RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/private/ssl-cert-snakeoil.key -out /etc/ssl/certs/ssl-cert-snakeoil.pem -subj "/CN=localhost"
+RUN mkdir /etc/apache2/ssl \
+    && openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/apache2/ssl/localhost.key -out /etc/apache2/ssl/localhost.crt -subj "/CN=localhost"
 
 # enable apache modules
 RUN a2enmod expires headers rewrite ssl
-RUN a2ensite default-ssl
 
 # install extensions
 RUN apt-get update -q && apt-get install -qy \

--- a/docker/php-apache/apache.conf
+++ b/docker/php-apache/apache.conf
@@ -1,9 +1,19 @@
-Listen 20080
-Listen 20443
+ServerName localhost
 
-<VirtualHost *:20080 *:20443>
+<VirtualHost *:80>
     ServerAdmin webmaster@localhost
     DocumentRoot /var/www/html
     ErrorLog ${APACHE_LOG_DIR}/error.log
     CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    SSLEngine on
+    SSLCertificateFile  /etc/apache2/ssl/localhost.crt
+    SSLCertificateKeyFile /etc/apache2/ssl/localhost.key
 </VirtualHost>

--- a/docker/php-apache/default.config.yml
+++ b/docker/php-apache/default.config.yml
@@ -1,7 +1,7 @@
 setup: true
 debug: false
 instname: null
-server: http://localhost:20080
+server: http://localhost
 servername: REDAXO
 error_email: null
 fileperm: '0664'


### PR DESCRIPTION
Wir hatten Docker über lange Zeit auf den 20000er-Ports laufen — 20080 (http), 20443 (https) und 23306 (db) —, damit keine Konflikte entstehen, wenn die Standardports belegt sind. Seit einiger Zeit sind wir aber dazu übergegangen, doch die Standardports zu verwenden, und ich würde das gerne auch in diesem Paket einbringen wollen.

Ein schöner Vorteil fürs REDAXO-Umfeld wäre dann, dass der Aufruf im Browser nur noch über `localhost` passiert, ohne Angabe eines Ports, und dass anhand des Schemas zwischen http und https unterschieden wird. Damit kann man dann auch viel eleganter Rewrite-Regeln definieren und testen.

Der PR enthält alles, was notwendig ist, und ich würde ihn irgendwann demnächst mergen, wenn das okay für euch ist.