### PR TITLE
change libpng12-dev to libpng-dev

### DIFF
--- a/docker/php-apache/Dockerfile
+++ b/docker/php-apache/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -q && apt-get install -qy \
        libfreetype6-dev \
        libjpeg62-turbo-dev \
        libmcrypt-dev \
-       libpng12-dev \
+       libpng-dev \
        ssmtp \
        unzip \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \


### PR DESCRIPTION
Avoid error: Package libpng12-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'libpng12-dev' has no installation candidate