### PR TITLE
chmod src/addons and assets/addons for sim linked addons

### DIFF
--- a/docker/php-apache/docker-entrypoint.sh
+++ b/docker/php-apache/docker-entrypoint.sh
@@ -58,5 +58,8 @@ fi
 # clean up tmp folder
 rm -rf /tmp/redaxo
 
+# set chmod for sim linked addon paths and assets
+chown -R www-data:www-data /redaxo/src/addons && chown -R www-data:www-data /redaxo/assets
+
 # execute CMD
 exec "$@"


### PR DESCRIPTION
Ich hatte Probleme mit dem addons die ich als simlink in den mountfolder gelinkt hatte. Mit dem chmod kann nach einem rebuild vom Container das Problem mit den rechten behoben werden.