### PR TITLE
Blackfire Implementierung

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - 28025:8025                          # mailhog will use port 28025 (for its web interface)
       
   blackfire:
+    container_name: redaxo_blackfire
+    hostname: redaxo_blackfire
     image: blackfire/blackfire
     environment:
       BLACKFIRE_CLIENT_ID: BLACKFIRE_CLIENT_ID          #replace with credentials found on https://blackfire.io/my/settings/credentials

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,3 +42,11 @@ services:
     ports:
       - 1025:1025                           # mailhog will use port 1025 (for smtp)
       - 28025:8025                          # mailhog will use port 28025 (for its web interface)
+      
+  blackfire:
+    image: blackfire/blackfire
+    environment:
+      BLACKFIRE_CLIENT_ID: BLACKFIRE_CLIENT_ID          #replace with credentials found on https://blackfire.io/my/settings/credentials
+      BLACKFIRE_CLIENT_TOKEN: BLACKFIRE_CLIENT_TOKEN    #replace with credentials found on https://blackfire.io/my/settings/credentials
+      BLACKFIRE_SERVER_ID: BLACKFIRE_SERVER_ID          #replace with credentials found on https://blackfire.io/my/settings/credentials
+      BLACKFIRE_SERVER_TOKEN: BLACKFIRE_SERVER_TOKEN    #replace with credentials found on https://blackfire.io/my/settings/credentials

--- a/docker/php-apache/Dockerfile
+++ b/docker/php-apache/Dockerfile
@@ -54,3 +54,12 @@ ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 # start apache
 CMD ["apache2-foreground"]
+
+# enable blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get ('extension_dir');")/blackfire.so \
+    && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz


### PR DESCRIPTION
Hey,

so hab ich eben in einer Docker Instanz Blackfire ans Laufen gebracht. Grundsätzlich muss `Dockerfile` und `docker-compose.yml` angepasst werden. In der `docker-compose.yml` müssen zusätzlich noch die Credentials aus dem eigenen Blackfire Account eingesetzt werden.

Getestet habe ich das eben mit dem Browser Client, der über die Demo gelaufen ist. Wie man es am Besten bereitstellt, müsste man sich aber nochmal überlegen, denke ich. Gerade um die Credentials leicht handhaben zu können.